### PR TITLE
chore: drop Node.js <= 12 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "standard-version": "^4.4.0"
   },
   "engines": {
-    "node": "6.* || >= 7.*"
+    "node": "14.* || 16.* || >= 18"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
Per https://nodejs.org/en/about/releases/ reaches End Of Life on 2022-04-30 which is this month.