### PR TITLE
Introduce etag cache mechanism

### DIFF
--- a/packages/ember-runtime-config/middleware/index.js
+++ b/packages/ember-runtime-config/middleware/index.js
@@ -1,20 +1,40 @@
 'use strict';
 
 const theredoc = require('theredoc');
+const crypto = require('crypto');
 const getConfig = require('../lib/get-config.js');
 
-module.exports = function (projectRoot) {
+module.exports = function (projectRoot, useEtag = false) {
   const runtimeConfig = getConfig(projectRoot);
+
   const scriptContent = theredoc`
-    (function(context) {
-      context._erc = ${JSON.stringify(runtimeConfig)};
-    })(window);
-  `;
+(function(context) {
+context._erc = ${JSON.stringify(runtimeConfig)};
+})(window);
+`;
+
+  let etag;
+
+  if (useEtag) {
+    etag = crypto.createHash('sha1').update(scriptContent).digest('hex');
+  }
 
   return (req, res, next) => {
     if (req.path === '/__/env.js') {
       res.set('Content-Type', 'application/javascript');
-      res.set('Cache-Control', 'max-age=0, no-cache, no-store');
+
+      if (useEtag) {
+        res.set('Cache-Control', 'max-age=0, no-cache');
+        res.set('ETag', etag);
+
+        if (req.headers['if-none-match'] === etag) {
+          res.status(304).end();
+          return;
+        }
+      } else {
+        res.set('Cache-Control', 'max-age=0, no-cache, no-store');
+      }
+
       res.send(scriptContent);
     } else {
       next();


### PR DESCRIPTION
It introduces second argument to middleware/index.js function which would accept useEtag boolean argument that can be used to set etag response header and respond with 304 status code if etag matches current script content.